### PR TITLE
Support $XDG_CONFIG_HOME for config location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ git config --global diff.csv.wordRegex $'[^,\n]+[,\n]|[,]'
 git config --global alias.diffcsv "diff --word-diff"
 
 # Setup CSV diff in gitattributes
-ATTR_FILE_DIR="${HOME}/.config/git"
+ATTR_FILE_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/git"
 ATTR_FILE="${ATTR_FILE_DIR}/attributes"
 # Make sure attribute file and directory exist
 mkdir -p ${ATTR_FILE_DIR}


### PR DESCRIPTION
Saw this mentioned on HN, and love the idea.  Thanks for creating it!

---

The `~/.config` location is just a fallback for when `$XDG_CONFIG_HOME` isn't set.  See [XDG basedir](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables) or scan the `git-config`/`gitattributes` manual pages for details.

Thanks,

James
